### PR TITLE
Fix storybook warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 	},
 	"exports": {
 		".": "./lib/index.js",
-		"./dedupe": "./lib/dedupe.js"
+		"./dedupe": "./lib/dedupe.js",
+		"./package.json": "./package.json"
 	},
 	"homepage": "https://github.com/ekim088/classnames#readme",
 	"keywords": [


### PR DESCRIPTION
Fixing the following storybook warning:
```
WARN unable to find package.json for @ekim088/classnames
```
caused by having an `exports` field in `package.json` that did not re-export the file.